### PR TITLE
Added roo-xls

### DIFF
--- a/lib/spree/importer_core/base_importer.rb
+++ b/lib/spree/importer_core/base_importer.rb
@@ -1,4 +1,5 @@
 require 'roo'
+require 'roo-xls'
 
 module Spree
   module ImporterCore
@@ -79,6 +80,10 @@ module Spree
         # Returns a Roo instance acording the file extension.
         def open_spreadsheet
           @spreadsheet = Roo::Spreadsheet.open(@filepath, extension: :xlsx)
+          @spreadsheet.default_sheet = @spreadsheet.sheets.first
+        rescue Zip::Error
+          # Supports spreadsheets with extension .xls
+          @spreadsheet = Roo::Spreadsheet.open(@filepath)
           @spreadsheet.default_sheet = @spreadsheet.sheets.first
         rescue => e
           add_error message: e.message, backtrace: e.backtrace, row_index: nil, data: {}

--- a/spree_importer_core.gemspec
+++ b/spree_importer_core.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl', '~> 4.4'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.13'
-  s.add_development_dependency 'sass-rails', '~> 4.0.2'
+  s.add_development_dependency 'sass-rails', '~> 5.0.0.beta1'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
 
   # Roo provides an interface to Open Office, Excel, and Google Spreadsheets
   s.add_dependency 'roo'
+  s.add_dependency 'roo-xls'
 end


### PR DESCRIPTION
Las planillas de ejemplo se generan como .xls, pero roo no soporta .xls, entonces se agrega soporte con roo-xls
